### PR TITLE
Added edge osx to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following should generally work, details are below.
 - Chrome on macOS
 - Chrome on Windows, with experimental flag
 - Edge on Windows, with experimental flag
+- Edge on OSX
 - Chrome on Linux\*, with experimental flag
 - Chrome on Android, without audio\*\*
 


### PR DESCRIPTION
Tested as working as of at least Version 89.0.774.75 (Official build) (64-bit)