### PR TITLE
Add default settings via urlParams

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -157,6 +157,12 @@ function setupConnection(connection, errorMessage) {
                 hide('#info');
                 show(errorMessage);
             }));
+    
+    if (Settings.load('skipInfo', false)) {
+      setTimeout(() => {
+        document.querySelector('#connect').click()
+      }, 2000)
+    }
 
     on(window, 'beforeunload', e =>
         connection.disconnect());

--- a/js/settings.js
+++ b/js/settings.js
@@ -100,6 +100,20 @@ function setupButton(setting, title) {
 }
 
 export function load(setting, defaultValue) {
+    const urlParams = new URLSearchParams(window.location.search)
+    if (urlParams.has(setting)) {
+      const urlValue = urlParams.get(setting)
+      if (typeof defaultValue == 'boolean') {
+        defaultValue = JSON.parse(urlValue) // parse true/false
+      } else if (setting == 'inputMap') {
+        defaultValue = {
+          ...defaultValue,
+          ...JSON.parse(urlValue)
+        }
+      } else {
+        defaultValue = urlParams.get(setting)
+      }
+    }
     let value = localStorage[setting];
     value = value === undefined ? defaultValue : JSON.parse(value);
     values[setting] = value;
@@ -121,5 +135,9 @@ export function onChange(setting, action) {
 }
 
 export function get(setting) {
+    const urlParams = new URLSearchParams(window.location.search)
+    if (urlParams.has(setting)) {
+      return urlParams.get(setting)
+    }
     return values[setting];
 }

--- a/js/util.js
+++ b/js/util.js
@@ -31,7 +31,9 @@ export function appendButton(target, title, onClick) {
     on(button, 'click', onClick);
 
     if (typeof target === 'string') {
+
         target = document.querySelector(target)
+
     }
 
     target.append(button);


### PR DESCRIPTION
I am deploying m8WebDisplay to a raspberryPi-based environment as an alternative to the rPi/m8c stack. I find m8WebDisplay to be more straightforward to customize, and it's browser level abstractions greatly simplify integration with the host. This way, one is not searching for how to get Alsa to play with m8c, but just how to get alsa to work with chrome. 

One barrier I ran into, is that the webgl renderer wouldn't work on chromium/aarch64. It failed in a strange way, the "#connect" button wouldn't show up. So I implemented these changes so the initial URL i setup for the chromium kiosk would default to `displayType=old`. I also implemented support for specifying the keymap via urlparam as well. Settings specified here will selectively overwrite the default keymap. Additionally, I added a setting to automatically skip the info screen. 

My rPi chromium instance can be thus pointed to something like:
```

localhost:8000/?displayType=old&skipInfo=true&inputMap={"KeyT": 'select}
```